### PR TITLE
自分のウィンドウ取得方法強化ほか

### DIFF
--- a/Assets/UniWinApi/Scripts/UniWinApi.cs
+++ b/Assets/UniWinApi/Scripts/UniWinApi.cs
@@ -37,17 +37,18 @@ public class UniWinApi : IDisposable {
 			hWnd = hwnd;
 			if (hWnd == IntPtr.Zero) return;
 
-			int len;
-			StringBuilder sb = new StringBuilder(1024);
+			const int len = 1024;
+			StringBuilder sb = new StringBuilder(len);
 
 			// クラス名を取得
-			if (WinApi.GetClassName(hWnd, sb, out len) > 0)
+			if (WinApi.GetClassName(hWnd, sb, len) > 0)
 			{
 				ClassName = sb.ToString();
 			}
 
 			// ウィンドウタイトルを取得
-			if (WinApi.GetWindowText(hWnd, sb, out len) > 0)
+			sb.Length = 0;	// StringBuilder内を消去
+			if (WinApi.GetWindowText(hWnd, sb, len) > 0)
 			{
 				Title = sb.ToString();
 			}
@@ -61,7 +62,7 @@ public class UniWinApi : IDisposable {
 
 		public override string ToString()
 		{
-			return string.Format("HWND:{0} {1} - {2}", hWnd, ProcessName, Title);
+			return string.Format("HWND:{0} Proc:{1} Title:{2} Class:{3}", hWnd, ProcessName, Title, ClassName);
 		}
 	}
 
@@ -361,6 +362,16 @@ public class UniWinApi : IDisposable {
 	}
 
 	/// <summary>
+	/// 現在のアクティブウインドウが自分自身ならばtrueを返す
+	/// </summary>
+	/// <returns></returns>
+	public bool CheckActiveWindow()
+	{
+		IntPtr hwnd = WinApi.GetActiveWindow();
+		return (hwnd == hWnd);
+	}
+
+	/// <summary>
 	/// ウィンドウスタイルを監視して、替わっていれば戻す
 	/// </summary>
 	public void Update() {
@@ -504,14 +515,18 @@ public class UniWinApi : IDisposable {
 	}
 
 	/// <summary>
-	/// Gets the Unity product-name
+	/// Get the Unity executable file name
 	/// </summary>
 	/// <description>http://gamedev.stackexchange.com/questions/68784/how-do-i-access-the-product-name-in-unity-4</description>
 	/// <returns>The project name.</returns>
-	public static string GetProjectName() {
-		string[] s = Application.dataPath.Split('/');
-		string projectName = s[s.Length - 2];
-		return projectName;
+	public static string GetUnityProcessName() {
+		string[] fileOrFolders = Application.dataPath.Split('/');
+		string file =  fileOrFolders[fileOrFolders.Length - 1];
+		if (file.Substring(file.Length - 4).ToLower() == ".exe")
+		{
+			file = file.Substring(0, file.Length - 4);
+		}
+		return file;
 	}
 
 #region マウス操作関連
@@ -734,15 +749,23 @@ public class UniWinApi : IDisposable {
 		{
 			EndFileDrop();
 #if UNITY_EDITOR
-			EnableTransparent(false);
-			EnableTopmost(false);
-			Restore();
-			RestoreWindowState();
+			Reset();
 #endif
 		}
 
 		hWnd = IntPtr.Zero;
 	}
 
-#endregion
+	/// <summary>
+	/// ウィンドウ状態を最初に戻す
+	/// </summary>
+	public void Reset()
+	{
+		EnableTransparent(false);
+		EnableTopmost(false);
+		Restore();
+		RestoreWindowState();
+	}
+
+	#endregion
 }

--- a/Assets/UniWinApi/Scripts/UniWinApi.cs
+++ b/Assets/UniWinApi/Scripts/UniWinApi.cs
@@ -519,6 +519,7 @@ public class UniWinApi : IDisposable {
 	/// </summary>
 	/// <description>http://gamedev.stackexchange.com/questions/68784/how-do-i-access-the-product-name-in-unity-4</description>
 	/// <returns>The project name.</returns>
+	[Obsolete]
 	public static string GetUnityProcessName() {
 		string[] fileOrFolders = Application.dataPath.Split('/');
 		string file =  fileOrFolders[fileOrFolders.Length - 1];

--- a/Assets/UniWinApi/Scripts/Wrappers/WinApi.cs
+++ b/Assets/UniWinApi/Scripts/Wrappers/WinApi.cs
@@ -103,18 +103,15 @@ public class WinApi {
 	
 	[DllImport("user32.dll", CharSet = CharSet.Auto)]
 	public static extern int GetWindowText (IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+	[DllImport("user32.dll", CharSet = CharSet.Auto)]
+	public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
 	
 	[DllImport("user32.dll")]
 	public static extern uint GetWindowThreadProcessId (IntPtr hWnd, out long lpdwProcessId);
 	
 	[DllImport("user32.dll")]
 	public static extern IntPtr FindWindow (string lpszClass, string lpszTitle);
-
-	[DllImport("user32.dll")]
-	public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, out int nMaxCount);
-
-	[DllImport("user32.dll")]
-	public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpTitle, out int nMaxCount);
 
 	[DllImport("user32.dll")]
 	public static extern long GetWindowRect (IntPtr hWnd, out RECT rect);

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -55,7 +55,7 @@ PlayerSettings:
   androidShowActivityIndicatorOnLoading: -1
   tizenShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
-  displayResolutionDialog: 1
+  displayResolutionDialog: 2
   iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
   allowedAutorotateToPortraitUpsideDown: 1


### PR DESCRIPTION
WindowController.cs
[Fix] 自分自身のウィンドウ取得方法を強化。他アプリのウィンドウと間違えにくくした。
[Fix] 他のウィンドウではないかのチェックを追加。
[Fix] 他のウィンドウだったときの処理を強化。

WinApi.cs, UniWinApi.cs
[Fix] GetWindowText()、GetClassName() が間違っていたので修正。

UniWinApi
[Add] ウィンドウ状態を通常に戻す Reset() を追加。
[Disable] GetProjectName() はやめる。
[Add] 代わりに GetUnityProcessName() を作ったが、仕様は定まらないので非推奨。